### PR TITLE
Fix stale StartupOrchestrator build registrations

### DIFF
--- a/WatchTower/Services/StartupOrchestrator.cs
+++ b/WatchTower/Services/StartupOrchestrator.cs
@@ -78,20 +78,11 @@ public class StartupOrchestrator : IStartupOrchestrator
             services.AddSingleton<IAdaptiveCardService, AdaptiveCardService>();
             services.AddSingleton<IGameControllerService, GameControllerService>();
 
-            // Register HttpClientFactory for HTTP-based services
-            services.AddHttpClient();
-
-            // Register Developer Build Menu services
-            services.AddSingleton<IBuildCacheService, BuildCacheService>();
-            services.AddSingleton<IGitHubBuildService, GitHubBuildService>();
-
             logger.Info("UserPreferencesService registered");
             logger.Info("CredentialStorageService registered");
             logger.Info("AdaptiveCardThemeService registered");
             logger.Info("AdaptiveCardService registered");
             logger.Info("GameControllerService registered");
-            logger.Info("BuildCacheService registered");
-            logger.Info("GitHubBuildService registered");
 
             // Register MCP handler
             services.AddMcpHandler(config =>


### PR DESCRIPTION
## Summary
- remove stale developer build menu DI registrations from StartupOrchestrator
- stop registering missing build-cache and GitHub-build services that are not present on current main
- restore the shared WatchTower baseline so Dependabot branches stop inheriting this compile failure

## Linked issue
Closes #338

## Validation
- dotnet build WatchTower.slnx -c Debug
- dotnet test WatchTower.slnx -c Debug --no-build
- dotnet run --project WatchTower/WatchTower.csproj -c Debug startup smoke check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/watchtower/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
